### PR TITLE
INTERLOK-3181 Upgrade to POI to 4.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target
 bin
 unit-tests.properties
 gradle.properties
+/.gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.30'
-  poiVersion = '4.1.1'
+  poiVersion = '4.1.2'
 
 }
 

--- a/src/main/java/com/adaptris/core/poi/ExcelConverter.java
+++ b/src/main/java/com/adaptris/core/poi/ExcelConverter.java
@@ -58,21 +58,23 @@ class ExcelConverter {
     int nRows = getRowCount(sheet);
     int nCells = getCellCount(sheet);
     context.logger().trace("Sheet {} has {} rows with {} cells", sheet.getSheetName(), nRows, nCells);
-    int rowCounter = sheet.getFirstRowNum();
-    String[] columnNames = createColumnNames(sheet, styleGuide);
-    if (styleGuide.resolveNamingStrategy() == ElementNaming.HEADER_ROW) {
-      rowCounter = styleGuide.headerRow();
-    }
-    // Now loop through and create each row.
-    for (; rowCounter < nRows; rowCounter++) {
-      Row row = sheet.getRow(rowCounter);
-      if (row == null) {
-        if (!context.ignoreNullRows()) {
-          throw new Exception("Unable to process row " + (rowCounter + 1) + "; it's null");
-        }
+    if (nRows > 0) {
+      int rowCounter = sheet.getFirstRowNum();
+      String[] columnNames = createColumnNames(sheet, styleGuide);
+      if (styleGuide.resolveNamingStrategy() == ElementNaming.HEADER_ROW) {
+        rowCounter = styleGuide.headerRow();
       }
-      else {
-        processRow(row, sheetElement, styleGuide, columnNames);
+      // Now loop through and create each row.
+      for (; rowCounter < nRows; rowCounter++) {
+        Row row = sheet.getRow(rowCounter);
+        if (row == null) {
+          if (!context.ignoreNullRows()) {
+            throw new Exception("Unable to process row " + (rowCounter + 1) + "; it's null");
+          }
+        }
+        else {
+          processRow(row, sheetElement, styleGuide, columnNames);
+        }
       }
     }
   }
@@ -94,7 +96,7 @@ class ExcelConverter {
       CellHandler handler = ExcelHelper.getHandler(cell);
       String value = handler.getValue(cell, styleGuide);
       String type = handler.getType();
-      context.logger().trace("Cell ({},{}) is a [{}] and the computed value is [{}]", rowCounter, (i+1), type, value);
+      context.logger().trace("Cell ({},{}) is a [{}] and the computed value is [{}]", rowCounter, i+1, type, value);
       // if showDataTypes is true, add the attribute to the xml node
       if (styleGuide.emitDataTypeAttr()) {
         cellElement.setAttribute(XML_ATTR_TYPE, type);

--- a/src/main/java/com/adaptris/core/poi/ExcelToXml.java
+++ b/src/main/java/com/adaptris/core/poi/ExcelToXml.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 import com.adaptris.annotation.AdapterComponent;
@@ -101,10 +100,12 @@ public class ExcelToXml extends ServiceImp implements ExcelConverter.ExcelConver
     this.ignoreNullRows = b;
   }
   
+  @Override
   public boolean ignoreNullRows() {
     return BooleanUtils.toBooleanDefaultIfNull(getIgnoreNullRows(), false);
   }
 
+  @Override
   public Logger logger() {
     return this.log;
   }

--- a/src/test/java/com/adaptris/core/poi/PoiServiceTest.java
+++ b/src/test/java/com/adaptris/core/poi/PoiServiceTest.java
@@ -1,13 +1,18 @@
 package com.adaptris.core.poi;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -16,14 +21,16 @@ import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceCase;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 
 public class PoiServiceTest extends ServiceCase {
   public static final String KEY_SAMPLE_INPUT = "poi.sample.input";
+  public static final String KEY_SAMPLE_INPUT_WITH_NULL = "poi.sample.input.null";
   private DefaultMessageFactory dMessageFactory = new DefaultMessageFactory();
-  
+
   public PoiServiceTest() {
     super();
   }
@@ -37,14 +44,14 @@ public class PoiServiceTest extends ServiceCase {
   protected Object retrieveObjectForCastorRoundTrip() {
     return new ExcelToXml();
   }
-  
+
   protected static byte[] readFile(String path) throws IOException {
     try (ByteArrayOutputStream out = new ByteArrayOutputStream(); InputStream in = new FileInputStream(new File(path))){
       IOUtils.copy(in, out);
-      return out.toByteArray();      
+      return out.toByteArray();
     }
   }
-  
+
   @Test
   public void testService() throws Exception {
     AdaptrisMessage msg = dMessageFactory.newMessage(readFile(PROPERTIES.getProperty(KEY_SAMPLE_INPUT)));
@@ -54,18 +61,53 @@ public class PoiServiceTest extends ServiceCase {
       start(service);
       service.doService(msg);
       Document d = XmlHelper.createDocument(msg, DocumentBuilderFactoryBuilder.newInstance());
-      XPath xp = new XPath();
-      assertNotNull(xp.selectSingleNode(d, "/spreadsheet/sheet[@name='Sheet1']"));
-      assertTrue(xp.selectNodeList(d, "/spreadsheet/sheet[@name='Sheet1']/row/cell").getLength() > 0);
-      assertNull(xp.selectSingleNode(d, "/spreadsheet/sheet[@name='Sheet1']/row/cell[@position='A1']"));
+      assertDocument(d);
     }
     finally {
       stop(service);
     }
   }
-  
+
+  @Test
+  public void testServiceIgnoreNullRowsFalse() throws Exception {
+    AdaptrisMessage msg = dMessageFactory.newMessage(readFile(PROPERTIES.getProperty(KEY_SAMPLE_INPUT_WITH_NULL)));
+    ExcelToXml service = new ExcelToXml();
+    service.getXmlStyle().setXmlEncoding("UTF-8");
+    try {
+      start(service);
+      ServiceException serviceException = assertThrows(ServiceException.class, () -> service.doService(msg));
+      assertEquals(Exception.class, serviceException.getCause().getClass());
+      assertEquals("Unable to process row 5; it's null", serviceException.getCause().getMessage());
+    } finally {
+      stop(service);
+    }
+  }
+
+  @Test
+  public void testServiceIgnoreNullRowsTrue() throws Exception {
+    AdaptrisMessage msg = dMessageFactory.newMessage(readFile(PROPERTIES.getProperty(KEY_SAMPLE_INPUT_WITH_NULL)));
+    ExcelToXml service = new ExcelToXml();
+    service.getXmlStyle().setXmlEncoding("UTF-8");
+    service.setIgnoreNullRows(true);
+    try {
+      start(service);
+      service.doService(msg);
+      Document d = XmlHelper.createDocument(msg, DocumentBuilderFactoryBuilder.newInstance());
+      assertDocument(d);
+    } finally {
+      stop(service);
+    }
+  }
+
+  private void assertDocument(Document d) throws XPathExpressionException {
+    XPath xp = new XPath();
+    assertNotNull(xp.selectSingleNode(d, "/spreadsheet/sheet[@name='Sheet1']"));
+    assertTrue(xp.selectNodeList(d, "/spreadsheet/sheet[@name='Sheet1']/row/cell").getLength() > 0);
+    assertNull(xp.selectSingleNode(d, "/spreadsheet/sheet[@name='Sheet1']/row/cell[@position='A1']"));
+  }
+
   @Override
   public boolean isAnnotatedForJunit4() {
     return true;
-  }   
+  }
 }


### PR DESCRIPTION
## Motivation

The upgraded to 4.1.2 could not be done because of tests failure.

## Modification

There is a changed of behaviour in 4.1.2 where Sheet#getFirstRowNum return -1 instead of 0 when there is no row (https://poi.apache.org/changes.html#4.1.2 and https://bz.apache.org/bugzilla/show_bug.cgi?id=63749).
So now we don't try to process any row if there is none.

Add .gradle to gitignore

## Result

POI upgraded to 4.1.2 and the tests are successful.

## Testing

Run the tests.
