### PR TITLE
fix: Support columns that extend past 'ZZ'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.36'
-  mockitoVersion = '4.5.1'
+  mockitoVersion = '4.6.0'
   poiVersion = '4.1.2'
 
 }

--- a/src/main/java/com/adaptris/core/poi/ExcelHelper.java
+++ b/src/main/java/com/adaptris/core/poi/ExcelHelper.java
@@ -38,12 +38,6 @@ class ExcelHelper {
 
   static final int LETTERS_IN_ALPHABET = 26;
 
-  private static final String[] INVALID_CHARS =
-  {
-      "\\\\", "\\?", "\\*", "\\:", " ", "\\|", "&", "\\\"", "\\'", "<", ">", "\\)", "\\(", "\\/"
-  };
-  private static final String REPLACEMENT_VALUE = "_";
-
   private static final GuidGenerator guid = new GuidGenerator();
 
   // Obtuse use of enums as both an interface and factory...
@@ -96,8 +90,7 @@ class ExcelHelper {
           }
           catch (Exception e1) {
             // Expect this error if the cell contains an invalid formula
-            String errorString = FormulaError.forInt(cell.getErrorCellValue()).getString();
-            return errorString;
+            return FormulaError.forInt(cell.getErrorCellValue()).getString();
           }
         }
       }
@@ -137,8 +130,8 @@ class ExcelHelper {
       }
     };
 
-    String myType;
-    CellType myCellType;
+    final String myType;
+    final CellType myCellType;
 
     CellHandler(String type, CellType cellType) {
       myType = type;
@@ -157,7 +150,7 @@ class ExcelHelper {
     public String getType() {
       return myType;
     }
-  };
+  }
 
   static CellHandler getHandler(Cell cell) throws Exception {
     if (cell == null) {
@@ -214,11 +207,10 @@ class ExcelHelper {
     // are zero indexed.
     int cell = colNumber + 1;
     StringBuilder cellName = new StringBuilder();
-    int asciiIndex = 0;
     while (cell > 0) {
-      asciiIndex = (cell - 1) % LETTERS_IN_ALPHABET;
+      int asciiIndex = (cell - 1) % LETTERS_IN_ALPHABET;
       cellName.append((char) (asciiIndex + 'A'));
-      cell = (int) ((cell - asciiIndex) / LETTERS_IN_ALPHABET);
+      cell = (cell - asciiIndex) / LETTERS_IN_ALPHABET;
     }
     return cellName.reverse().toString();
   }

--- a/src/test/java/com/adaptris/core/poi/ExcelHelperTest.java
+++ b/src/test/java/com/adaptris/core/poi/ExcelHelperTest.java
@@ -1,0 +1,43 @@
+package com.adaptris.core.poi;
+
+import static com.adaptris.core.poi.ExcelHelper.createCellName;
+import static com.adaptris.core.poi.ExcelHelper.numericColumnName;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ExcelHelperTest {
+
+  @Test
+  public void testCreateCellName() throws Exception {
+    // Cells are zero-indexed.
+    int len = ExcelHelper.LETTERS_IN_ALPHABET;
+    assertEquals("A", createCellName(0));
+    assertEquals("AB", createCellName(len + 1));
+    assertEquals("ZZ", createCellName((len * len) + 25));
+    assertEquals("AAA", createCellName((len * len) + 26));
+    assertEquals("AAD", createCellName((len * len) + 29));
+
+    // Some well known columns.
+    assertEquals("CV", createCellName(99));
+    assertEquals("ALL", createCellName(999));
+    assertEquals("NTP", createCellName(9999));
+    // This is the logical max columns according to MS for an excel worksheet, max is 16384
+    assertEquals("XFD", createCellName(16383));
+  }
+
+  @Test
+  public void testNumericColumnName() throws Exception {
+
+    assertEquals(0, numericColumnName("A"));
+    assertEquals(27, numericColumnName("AB"));
+    assertEquals(702 , numericColumnName("ZZ") + 1);
+
+    assertEquals(100, numericColumnName("CV") + 1);
+    assertEquals(1000, numericColumnName("ALL") + 1);
+    assertEquals(10000, numericColumnName("NTP") + 1);
+    assertEquals(16384, numericColumnName("XFD") + 1);
+
+  }
+
+}


### PR DESCRIPTION
## Motivation

The maximum number of columns is 16384 according to microsoft which is column 'XFD'.

There is no support for columns that go into 3 letters and if you do, and if you have chosen CELL_POSITION as your xml style, then it fails with an IndexOutOfBoundsException.

## Modification

Change the way the names of the columns are computed to be less reliant on positional indexing of the enum. It generates the expected name for everything up to the nominal max-columns specified by Excel (16384) and should cope with greater than that.

Although not used, added a "numericColumnName" that turns AAA into it's number representation suitable for use in a zero-indexed based system (which POI is).

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

No change for the end user at configuration time.

If they have explicitly used `CELL_POSITION` as the XML Naming strategy and they have __> 702 __ columns in their spreadsheet, then excel-to-xml will no longer fail.

## Testing

Create a spreadsheet with > 702 columns and run it through the service with CELL_POSITION as the XML style; or trust that the unit tests from ExcelHelper gives you confidence.



